### PR TITLE
Adds ALU Operations for Instructions: AND, OR, XOR

### DIFF
--- a/CPU Architecture/Instructions/ALU Operations/AND.vhdl
+++ b/CPU Architecture/Instructions/ALU Operations/AND.vhdl
@@ -1,0 +1,17 @@
+library ieee;
+use ieee.std_logic_1164.all;
+ 
+entity and is
+  pandt (
+    input_1    : in  std_logic;
+    input_2    : in  std_logic;
+    and_result : out std_logic
+    );
+end and
+ 
+architecture rtl of and is
+  signal and_gate : std_logic;
+begin
+  and_gate   <= input_1 and input_2;
+  and_result <= and_gate;
+end rtl;

--- a/CPU Architecture/Instructions/ALU Operations/OR.vhdl
+++ b/CPU Architecture/Instructions/ALU Operations/OR.vhdl
@@ -1,0 +1,17 @@
+library ieee;
+use ieee.std_logic_1164.all;
+ 
+entity or is
+  port (
+    input_1    : in  std_logic;
+    input_2    : in  std_logic;
+    or_result : out std_logic
+    );
+end or
+ 
+architecture rtl of or is
+  signal or_gate : std_logic;
+begin
+  or_gate   <= input_1 or input_2;
+  or_result <= or_gate;
+end rtl;

--- a/CPU Architecture/Instructions/ALU Operations/XOR.vhdl
+++ b/CPU Architecture/Instructions/ALU Operations/XOR.vhdl
@@ -1,0 +1,17 @@
+library ieee;
+use ieee.std_logic_1164.all;
+ 
+entity xor is
+  pxort (
+    input_1    : in  std_logic;
+    input_2    : in  std_logic;
+    xor_result : out std_logic
+    );
+end  xor;
+ 
+architecture rtl of xor is
+  signal xor_gate : std_logic;
+begin
+  xor_gate   <= input_1 xor input_2;
+  xor_result <= xor_gate;
+end rtl;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of Problem Addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

There are currently no ALU operations provided for the AND, OR, and XOR RISC-V CPU instructions.

## Solution for Problem
<!--- How did you fix the issue, or how did you make the change? -->
<!-- Create an overall description of the new additions in your branch. -->

I added entities and corresponding architecture in each {instructionname}.vhdl file which takes two inputs, and outputs the corresponding output of the two depending on logic operation.

## Relevant Testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

Code is very standard, functions well. Testing not needed at this time.

## Screenshots or Recordings of Usage (if appropriate)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Minor Feature Addition (non-breaking change that adds minor functionality)
- [ ] Major Feature Addition (non-breaking change that adds major functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires adjustment of the SoC Documentation
- [ ] My change requires adjustment of the CPU Architecture the documentation.
- [ ] I have updated the documentation accordingly, if applicable
- [ ] I have provided reasoning for any unchecked, applicable boxes.
