### PR TITLE
Minor syntax fix, changes signals to 5-bit vectors

### DIFF
--- a/CPU Architecture/Instructions/ALU Operations/AND.vhdl
+++ b/CPU Architecture/Instructions/ALU Operations/AND.vhdl
@@ -2,15 +2,15 @@ library ieee;
 use ieee.std_logic_1164.all;
  
 entity and is
-  pandt (
-    input_1    : in  std_logic;
-    input_2    : in  std_logic;
-    and_result : out std_logic
+  and (
+    input_1    : in  std_logic_vector(4 downto 0);
+    input_2    : in  std_logic_vector(4 downto 0);
+    and_result : out std_logic_vector(4 downto 0);
     );
 end and
  
 architecture rtl of and is
-  signal and_gate : std_logic;
+  signal and_gate : std_logic_vector(4 downto 0);
 begin
   and_gate   <= input_1 and input_2;
   and_result <= and_gate;

--- a/CPU Architecture/Instructions/ALU Operations/OR.vhdl
+++ b/CPU Architecture/Instructions/ALU Operations/OR.vhdl
@@ -2,15 +2,15 @@ library ieee;
 use ieee.std_logic_1164.all;
  
 entity or is
-  port (
-    input_1    : in  std_logic;
-    input_2    : in  std_logic;
-    or_result : out std_logic
+  or (
+    input_1    : in  std_logic_vector(4 downto 0);
+    input_2    : in  std_logic_vector(4 downto 0);
+    or_result : out std_logic_vector(4 downto 0)
     );
 end or
  
 architecture rtl of or is
-  signal or_gate : std_logic;
+  signal or_gate : std_logic_vector(4 downto 0);
 begin
   or_gate   <= input_1 or input_2;
   or_result <= or_gate;

--- a/CPU Architecture/Instructions/ALU Operations/XOR.vhdl
+++ b/CPU Architecture/Instructions/ALU Operations/XOR.vhdl
@@ -2,15 +2,15 @@ library ieee;
 use ieee.std_logic_1164.all;
  
 entity xor is
-  pxort (
-    input_1    : in  std_logic;
-    input_2    : in  std_logic;
-    xor_result : out std_logic
+  xor (
+    input_1    : in  std_logic_vector(4 downto 0);
+    input_2    : in  std_logic_vector(4 downto 0);
+    xor_result : out std_logic_vector(4 downto 0)
     );
 end  xor;
  
 architecture rtl of xor is
-  signal xor_gate : std_logic;
+  signal xor_gate : std_logic_vector(4 downto 0);
 begin
   xor_gate   <= input_1 xor input_2;
   xor_result <= xor_gate;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of Problem Addressed
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Previous code for AND, OR, and XOR instruction ALU Operations were using 1-bit input and output logic signals, which is not appropriate for RISC-V CPU instructions.

## Solution for Problem
<!--- How did you fix the issue, or how did you make the change? -->
<!-- Create an overall description of the new additions in your branch. -->

Adjusted input and output signals to be little endian 5-bit vectors.

## Relevant Testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Testing not yet appropriate at this time. The functionality of these ALU operations will be tested when the remainder of their instructions are complete.

## Screenshots or Recordings of Usage (if appropriate)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Minor Feature Addition (non-breaking change that adds minor functionality)
- [ ] Major Feature Addition (non-breaking change that adds major functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires adjustment of the SoC Documentation
- [ ] My change requires adjustment of the CPU Architecture the documentation.
- [ ] I have updated the documentation accordingly, if applicable
- [ ] I have provided reasoning for any unchecked, applicable boxes.
